### PR TITLE
fixed out of bounds memory access caused by module_bounds_length = 4

### DIFF
--- a/hal/src/nrf51/ota_flash_hal.c
+++ b/hal/src/nrf51/ota_flash_hal.c
@@ -50,7 +50,7 @@ const module_bounds_t* module_bounds[] = { &module_bootloader, &module_user, &mo
 const module_bounds_t module_ota = { 0x1D000, 0x1004000, 0x1021000, MODULE_FUNCTION_NONE, 0, MODULE_STORE_SCRATCHPAD};
 #endif
 
-const unsigned module_bounds_length = 4;
+const unsigned module_bounds_length = 3;
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved);
 
 /**


### PR DESCRIPTION
Hi

My compiler issued a warning ...

```
src/nrf51/ota_flash_hal.c:167:17: error: iteration 3u invokes undefined behavior [-Werror=aggressive-loop-optimizations]
                 fetch_module(info->modules+i, module_bounds[i], false, MODULE_VALIDATION_INTEGRITY);
                 ^
src/nrf51/ota_flash_hal.c:166:13: note: containing loop
             for (unsigned i=0; i<module_bounds_length; i++) {
             ^
```

I noted that the const `module_bounds[]` has only 3 entries now, compared to the 4 in the develop (non-gateway) branch.

So, this pull request ...

```
src/nrf51/ota_flash_hal.c:53:
const unsigned module_bounds_length = 3;
```

... fixes that. Build succeeds ... and is probably a little more stable as well. ;-)

Gruvin
