### PR TITLE
missing makefiles and module_bounds_length=[3|4] #if conditionals

### DIFF
--- a/hal/src/nrf51/ota_flash_hal.c
+++ b/hal/src/nrf51/ota_flash_hal.c
@@ -21,6 +21,7 @@
 #include "hw_config.h"
 #include "sst25vf_spi.h"
 
+
 #if MODULAR_FIRMWARE
 
 #if PLATFORM_ID==103   /*--bluz*/
@@ -30,6 +31,7 @@ const module_bounds_t module_user = { 0x5000, 0x37000, 0x3C000, MODULE_FUNCTION_
 const module_bounds_t module_factory = { 0x1F000, 0x1021000, 0x1040000, MODULE_FUNCTION_USER_PART, 1, MODULE_STORE_FACTORY};
 const module_bounds_t* module_bounds[] = { &module_bootloader, &module_system_part1, &module_user, &module_factory };
 const module_bounds_t module_ota = { 0x1D000, 0x1004000, 0x1021000, MODULE_FUNCTION_NONE, 0, MODULE_STORE_SCRATCHPAD};
+const unsigned module_bounds_length = 4;
 #endif
 
 #if PLATFORM_ID==269   /*--bluz-gw*/
@@ -39,6 +41,7 @@ const module_bounds_t module_user = { 0x5000, 0x37000, 0x3C000, MODULE_FUNCTION_
 const module_bounds_t module_factory = { 0x1F000, 0x1021000, 0x1040000, MODULE_FUNCTION_USER_PART, 1, MODULE_STORE_FACTORY};
 const module_bounds_t* module_bounds[] = { &module_bootloader, &module_system_part1, &module_user, &module_factory };
 const module_bounds_t module_ota = { 0x1D000, 0x1004000, 0x1021000, MODULE_FUNCTION_NONE, 0, MODULE_STORE_SCRATCHPAD};
+const unsigned module_bounds_length = 4;
 #endif
 
 #else
@@ -46,11 +49,10 @@ const module_bounds_t module_bootloader = { 0x4000, 0x3C000, 0x40000, MODULE_FUN
 const module_bounds_t module_user = { 0x24000, 0x18000, 0x3C000, MODULE_FUNCTION_MONO_FIRMWARE, 0, MODULE_STORE_MAIN};
 const module_bounds_t module_factory = { 0x1F000, 0x1021000, 0x1040000, MODULE_FUNCTION_MONO_FIRMWARE, 0, MODULE_STORE_FACTORY};
 const module_bounds_t* module_bounds[] = { &module_bootloader, &module_user, &module_factory };
-
 const module_bounds_t module_ota = { 0x1D000, 0x1004000, 0x1021000, MODULE_FUNCTION_NONE, 0, MODULE_STORE_SCRATCHPAD};
+const unsigned module_bounds_length = 3;
 #endif
 
-const unsigned module_bounds_length = 3;
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved);
 
 /**

--- a/hal/src/nrf51/ota_flash_hal.c
+++ b/hal/src/nrf51/ota_flash_hal.c
@@ -50,7 +50,7 @@ const module_bounds_t* module_bounds[] = { &module_bootloader, &module_user, &mo
 const module_bounds_t module_ota = { 0x1D000, 0x1004000, 0x1021000, MODULE_FUNCTION_NONE, 0, MODULE_STORE_SCRATCHPAD};
 #endif
 
-const unsigned module_bounds_length = 4;
+const unsigned module_bounds_length = 3;
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved);
 
 /**

--- a/modules/bluz-gw/makefile
+++ b/modules/bluz-gw/makefile
@@ -1,0 +1,4 @@
+include modular.mk
+
+%:
+	$(MAKE) -C .. $(MAKECMDGOALS) 

--- a/modules/bluz/makefile
+++ b/modules/bluz/makefile
@@ -1,0 +1,4 @@
+include modular.mk
+
+%:
+	$(MAKE) -C .. $(MAKECMDGOALS) 


### PR DESCRIPTION
My `make PLATFORM=bluz-gw` wasn't processing `modules/bluz/module.mk`. Adding a `makefile` to the folder fixed that. Ditto for `mopdules/bluz`. I suspect the files are present locally somewhere, just not in the repository -- or something?

Along the way to figuring this out, I noted that `module_bounds_length` should not `=4` when `MODULAR_FIRMWARE` is not defined ... because `module_bounds[]` only has three elements in that case. So, I moved `module_bounds_length=` to inside each of the `#if PLATFORM_ID` blocks.
