### PR TITLE
Add automatic buildpack building

### DIFF
--- a/.buildpackrc
+++ b/.buildpackrc
@@ -1,0 +1,21 @@
+# This file is used by https://github.com/spark/firmware-buildpack-builder to
+# build Docker images containing all toolchains and sources nessesary for
+# compilation.
+#
+# Additionally release/prerelease information is used to automatically create
+# build targets in Particle Cloud when pushing a tag.
+
+# GCC buildpack variation to use ( see: https://hub.docker.com/r/particle/buildpack-hal/tags/ )
+export BUILDPACK_VARIATION=gcc-arm-none-eabi-4_9-2015q3
+
+# Platforms for which this firmware is considered stable
+export RELEASE_PLATFORMS=( )
+# Platforms for which this firmware is considered experimental
+export PRERELEASE_PLATFORMS=( bluz bluz-gw )
+# Note: a single platform should be only in release or prerelease list. If
+# added to both it will be considered a prerelease
+
+# Platform IDs which require modules to be prebuild
+export MODULAR_PLATFORMS=( bluz bluz-gw )
+# Example GCC ARM version override for FOO platform
+export BUILDPACK_VARIATION_PLATFORM_FOO=gcc-arm-none-eabi-5_3-2016q1

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ env:
   # # Photon minimal build
   # - DIR=modules PLATFORM=photon COMPILE_LTO=n MINIMAL=y
   global:
-  - DOCKER_IMAGE_NAME=particle/buildpack-particle-firmware
+  - DOCKER_IMAGE_NAME=bluz/buildpack-bluz-firmware
   - secure: UM1+Ps1t21JfJaTFhuqkaY/U21j1Gfja6oSJTALcU0Y7zmo7TNyYMJwP+tbRfss7RBilWwUA8osr3sr6NXPREChojKpRQaRt52iD6wDfcxhsxGrpOU79cYO7FK1aQhCmhDGcnXahtxzbOGwS74jjTFW9U6TSveWa+EV1OgagLMc=
   - secure: aJ+EUGgXIp8t0s/f3EEyiUjYXnzAlYW9+jukG240A2Wb/XnGp9Av/JE+wBnBeMv7eF+hxkODo99gDXPumV6uYQevIBtqiHWtAu7kyvCxUWXhSmag+Q89pCJO8QpUrcxra9UZ6i+zhFEfskBctBjlT9nMKoUsGSg4jMg6Kx71QsA=
   - secure: Iq58mKqq5Nz4B6OEZu1nmnquhvlQncxT4T3f1x+M/0I6VW5xirMWFlpeke8QyyPOZlwNLDnB5QVjsR2UQspNIhMT4rCfDeCCr9AeinoMDmqPbzpmLLmtaUpz0uTZyJVx7+IRe9QtljPfbzlAxybmrx1HdCCw++F/+qhgFoGLi9o=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/spark/firmware.svg?branch=develop)](https://travis-ci.org/spark/firmware)
+[![Build Status](https://travis-ci.org/sbluzDK/bluzDK-firmware.svg?branch=develop)](https://travis-ci.org/bluzDK/bluzDK-firmware)
 
 # Particle Firmware for the Core, Photon and bluz
 


### PR DESCRIPTION
Hi Eric!

This PR will integrate you CI pipeline with automatic buildpack generation which later can be used to integrate with our new cloud compiler! I tested it [here](https://hub.docker.com/r/particle/buildpack-bluz-firmware/) but I can't confirm if resulting binary is ok (I don't have any Bluz devices).

Things you need to do before merging this PR:
- [x] Create Docker Hub account ( https://hub.docker.com/u/bluz/ )
- [x] Create `buildpack-bluz-firmware` public repository on Docker Hub
- [x] Enable Travis for https://travis-ci.org/bluzDK/bluzDK-firmware
- [x] Add `DOCKER_HUB_USERNAME`, `DOCKER_HUB_EMAIL` and `DOCKER_HUB_PASSWORD` environment variables in Travis

Once you're done and merge this PR, a Travis build should generate and push Docker image do Docker Hub. Then, each time you push a git tag it would build a main image, and platform specific images based on `.buildpackrc` file in your fw repo.

Cheers and much ❤️  from Particle!
